### PR TITLE
Added settings to restrict media tab to specific role

### DIFF
--- a/includes/bp-media-function.php
+++ b/includes/bp-media-function.php
@@ -961,3 +961,40 @@ function bp_media_get_option( $key = '', $default = false ) {
 function bp_media_enabled() {
 	return ( 'on' === bp_media_get_option( 'enable_reporting' ) );
 }
+
+/**
+ * Does user have an allowed user role access to media?
+ *
+ * @param  int $user_id User ID.
+ *
+ * @since  1.0.2
+ *
+ * @author  Kailan W.
+ *
+ * @return boolean.
+ */
+function bp_media_role_allowed( $user_id = 0 ) {
+	// Get allowed user roles.
+	$roles = bp_media_get_option( 'allowed_roles' );
+
+	// If roles are empty then allow.
+	if ( empty( $roles ) ) {
+		return true;
+	}
+
+	if ( ! $user_id ) {
+		$user_id = bp_loggedin_user_id();
+	}
+
+	// Get WP_User object.
+	$user_info = get_userdata( $user_id );
+	if ( ! empty( $user_info->roles ) ) {
+		foreach ( $user_info->roles as $role ) {
+			// Check if the current user role is in allowed set.
+			if ( in_array( $role, $roles ) ) {
+				return true;
+			}
+		}
+	}
+	return false;
+}

--- a/includes/bp-media-loader.php
+++ b/includes/bp-media-loader.php
@@ -107,12 +107,18 @@ class BP_Media_Component extends BP_Component {
 			'position'            => 10,
 			'screen_function'     => 'bp_media_screen_user_media',
 			'default_subnav_slug' => 'media',
-			'item_css_id'         => $this->id
+			'item_css_id'         => $this->id,
 		);
 
 		// Stop if there is no user displayed or logged in.
-		if ( !is_user_logged_in() && !bp_displayed_user_id() )
+		if ( ! is_user_logged_in() && ! bp_displayed_user_id() ) {
 			return;
+		}
+
+		// Check if this user is allowed to have media tab on their profile.
+		if ( ! bp_media_role_allowed( bp_displayed_user_id() ) ) {
+			return;
+		}
 
 		// Determine user to use.
 		if ( bp_displayed_user_domain() ) {
@@ -126,8 +132,9 @@ class BP_Media_Component extends BP_Component {
 		// User link.
 		$media_link = trailingslashit( $user_domain . $this->slug );
 
-		if ( !defined( 'BP_MEDIA_USER_SLUG' ) )
+		if ( ! defined( 'BP_MEDIA_USER_SLUG' ) ) {
 			define( 'BP_MEDIA_USER_SLUG', $media_link );
+		}
 
 		// Add the subnav items to the media nav item if we are using a theme that supports this.
 		$sub_nav[] = array(
@@ -136,7 +143,7 @@ class BP_Media_Component extends BP_Component {
 			'parent_url'      => $media_link,
 			'parent_slug'     => $this->slug,
 			'screen_function' => 'bp_media_screen_user_media',
-			'position'        => 10
+			'position'        => 10,
 		);
 
 		$sub_nav[] = array(
@@ -145,7 +152,7 @@ class BP_Media_Component extends BP_Component {
 			'parent_url'      => $media_link,
 			'parent_slug'     => $this->slug,
 			'screen_function' => 'bp_media_screen_user_media',
-			'position'        => 40
+			'position'        => 40,
 		);
 
 		$sub_nav[] = array(
@@ -154,28 +161,28 @@ class BP_Media_Component extends BP_Component {
 			'parent_url'      => $media_link,
 			'parent_slug'     => $this->slug,
 			'screen_function' => 'bp_media_screen_user_media',
-			'position'        => 40
+			'position'        => 40,
 		);
 
-		if( is_user_logged_in() ) {
+		if ( is_user_logged_in() ) {
 			$sub_nav[] = array(
 				'name'            => ' ',
 				'slug'            => 'create',
 				'parent_url'      => $media_link,
 				'parent_slug'     => $this->slug,
 				'screen_function' => 'bp_media_screen_user_media',
-				'position'        => 50
+				'position'        => 50,
 			);
 		}
 
-		if( is_user_logged_in() ) {
+		if ( is_user_logged_in() ) {
 			$sub_nav[] = array(
 				'name'            => ' ',
 				'slug'            => 'edit',
 				'parent_url'      => $media_link,
 				'parent_slug'     => $this->slug,
 				'screen_function' => 'bp_media_screen_user_media',
-				'position'        => 50
+				'position'        => 50,
 			);
 		}
 
@@ -187,7 +194,7 @@ class BP_Media_Component extends BP_Component {
 				'parent_slug'     => $this->slug,
 				'screen_function' => 'bp_media_screen_user_media',
 				'position'        => 20,
-				'user_has_access' => bp_is_friend_boolean() || bp_is_my_profile()
+				'user_has_access' => bp_is_friend_boolean() || bp_is_my_profile(),
 			);
 		}
 
@@ -198,7 +205,7 @@ class BP_Media_Component extends BP_Component {
 			'parent_slug'     => $this->slug,
 			'screen_function' => 'bp_media_screen_user_media',
 			'position'        => 30,
-			'user_has_access' => bp_is_my_profile()
+			'user_has_access' => bp_is_my_profile(),
 		);
 
 		/*
@@ -258,7 +265,7 @@ class BP_Media_Component extends BP_Component {
 		$bp = buddypress();
 
 		// Menus for logged in user.
-		if ( is_user_logged_in() ) {
+		if ( is_user_logged_in() && bp_media_role_allowed() ) {
 
 			// Setup the logged in user variables.
 			$user_domain   = bp_loggedin_user_domain();

--- a/includes/class-bp-media-admin-settings.php
+++ b/includes/class-bp-media-admin-settings.php
@@ -104,7 +104,7 @@ class BP_Media_Settings {
 				<a href="<?php echo admin_url( 'admin.php?page=' . $this->key . '&tab=reporting' ); ?>" class="nav-tab <?php echo 'reporting' == $active_tab  ? 'nav-tab-active' : ''; ?>"><?php _e( 'Reporting', 'um-learndash' ); ?></a>
 			</h2>
 			<?php
-			switch( $active_tab ) {
+			switch ( $active_tab ) {
 				case 'reporting':
 					cmb2_metabox_form( $this->metabox_id . '-reporting', $this->key );
 				break;
@@ -123,7 +123,11 @@ class BP_Media_Settings {
 	 * @return void
 	 */
 	public function add_options_page_metabox() {
-
+		if ( ! function_exists( 'get_editable_roles' ) ) {
+			require_once( ABSPATH . '/wp-admin/includes/user.php' );
+		}
+		$roles = get_editable_roles();
+		$roles = wp_list_pluck( $roles, 'name' );
 		$cmb = new_cmb2_box( array(
 			'id'         => $this->metabox_id,
 			'hookup'     => false,
@@ -135,51 +139,59 @@ class BP_Media_Settings {
 			),
 		) );
 
-        $cmb->add_field( array(
-        	'name'    => __( 'Media Types', 'buddymedia' ),
-        	'desc'    => __( 'Allowed media types.', 'buddymedia' ),
-        	'default' => '',
-        	'id'      => 'media_types',
-        	'type'    => 'title',
-        ) );
+		$cmb->add_field( array(
+			'name'    => __( 'Allowed User Roles', 'buddymedia' ),
+			'desc'    => __( 'Users with these roles will have the ability to upload photos. Leave blank to allow all roles', 'buddymedia' ),
+			'id'      => 'allowed_roles',
+			'type'    => 'multicheck',
+			'options' => $roles,
+		) );
 
-        $cmb->add_field( array(
-        	'name'    => __( 'Allowed extensions for images.', 'buddymedia' ),
-        	'desc'    => '',
-        	'default' => '',
-        	'id'      => 'bp_media_image_types',
-        	'type'    => 'text',
-        ) );
+		$cmb->add_field( array(
+			'name'    => __( 'Media Types', 'buddymedia' ),
+			'desc'    => __( 'Allowed media types.', 'buddymedia' ),
+			'default' => '',
+			'id'      => 'media_types',
+			'type'    => 'title',
+		) );
 
-        $cmb->add_field( array(
-        	'name'    => __( 'Allowed extensions for docs.', 'buddymedia' ),
-        	'desc'    => '',
-        	'default' => '',
-        	'id'      => 'bp_media_doc_types',
-        	'type'    => 'text',
-        ) );
+		$cmb->add_field( array(
+			'name'    => __( 'Allowed extensions for images.', 'buddymedia' ),
+			'desc'    => '',
+			'default' => '',
+			'id'      => 'bp_media_image_types',
+			'type'    => 'text',
+		) );
 
-        $cmb->add_field( array(
-        	'name'    => __( 'Storage Types', 'buddymedia' ),
-        	'desc'    => __( 'Allowed storage quotas.', 'buddymedia' ),
-        	'default' => '',
-        	'id'      => 'storage_types',
-        	'type'    => 'title',
-        ) );
+		$cmb->add_field( array(
+			'name'    => __( 'Allowed extensions for docs.', 'buddymedia' ),
+			'desc'    => '',
+			'default' => '',
+			'id'      => 'bp_media_doc_types',
+			'type'    => 'text',
+		) );
 
-        $cmb->add_field( array(
-        	'name'    => __( 'Maximum Upload size per file(MB)?', 'buddymedia' ),
-        	'desc'    => '',
-        	'default' => '',
-        	'id'      => 'bp_media_file_size',
-        	'type'    => 'text',
-        ) );
+		$cmb->add_field( array(
+			'name'    => __( 'Storage Types', 'buddymedia' ),
+			'desc'    => __( 'Allowed storage quotas.', 'buddymedia' ),
+			'default' => '',
+			'id'      => 'storage_types',
+			'type'    => 'title',
+		) );
+
+		$cmb->add_field( array(
+			'name'    => __( 'Maximum Upload size per file(MB)?', 'buddymedia' ),
+			'desc'    => '',
+			'default' => '',
+			'id'      => 'bp_media_file_size',
+			'type'    => 'text',
+		) );
 
 		/*
 		Add your fields here
 		*/
 
-        $cmb = new_cmb2_box( array(
+		$cmb = new_cmb2_box( array(
 			'id'         => $this->metabox_id . '-reporting',
 			'hookup'     => false,
 			'cmb_styles' => false,
@@ -191,19 +203,19 @@ class BP_Media_Settings {
 		) );
 
 		$cmb->add_field( array(
-        	'name'    => __( 'Turn on reporting', 'buddymedia' ),
-        	'id'      => 'enable_reporting',
-        	'desc'    => __( 'Enable repoting on media items', 'buddymedia' ),
-        	'type'    => 'checkbox',
-        ) );
+			'name'    => __( 'Turn on reporting', 'buddymedia' ),
+			'id'      => 'enable_reporting',
+			'desc'    => __( 'Enable repoting on media items', 'buddymedia' ),
+			'type'    => 'checkbox',
+		) );
 
-        $cmb->add_field( array(
-        	'name'       => __( 'Reporting Reasons', 'buddymedia' ),
-        	'id'         => 'bp_media_reporting_reasons',
-        	'desc'       => __( 'Enable repoting on media items', 'buddymedia' ),
-        	'type'       => 'text',
-        	'repeatable' => true,
-        ) );
+		$cmb->add_field( array(
+			'name'       => __( 'Reporting Reasons', 'buddymedia' ),
+			'id'         => 'bp_media_reporting_reasons',
+			'desc'       => __( 'Enable repoting on media items', 'buddymedia' ),
+			'type'       => 'text',
+			'repeatable' => true,
+		) );
 
 	}
 
@@ -213,53 +225,44 @@ class BP_Media_Settings {
  */
 function bp_media_admin_settings() {
 
-    /* This is how you add a new section to BuddyPress settings */
-    add_settings_section(
-        /* the id of your new section */
-        'bp_media_section',
+	/* This is how you add a new section to BuddyPress settings */
+	add_settings_section(
+		/* the id of your new section */
+		'bp_media_section',
+		/* the title of your section */
+		__( 'Media Settings',  'bp-media' ),
+		/* the display function for your section's description */
+		'bp_plugin_setting_callback_section',
+		/* BuddyPress settings */
+		'buddypress'
+	);
 
-        /* the title of your section */
-        __( 'Media Settings',  'bp-media' ),
+	/* This is how you add a new field to your plugin's section */
+	add_settings_field(
+		/* the option name you want to use for your plugin */
+		'bp-media-shared-gallery',
+		/* The title for your setting */
+		__( 'Shared Galleries', 'bp-media' ),
+		/* Display function */
+		'bp_media_setting_field_callback',
+		/* BuddyPress settings */
+		'buddypress',
+		/* Your plugin's section id */
+		'bp_media_section'
+	);
 
-        /* the display function for your section's description */
-        'bp_plugin_setting_callback_section',
-
-        /* BuddyPress settings */
-        'buddypress'
-    );
-
-    /* This is how you add a new field to your plugin's section */
-    add_settings_field(
-        /* the option name you want to use for your plugin */
-        'bp-media-shared-gallery',
-
-        /* The title for your setting */
-        __( 'Shared Galleries', 'bp-media' ),
-
-        /* Display function */
-        'bp_media_setting_field_callback',
-
-        /* BuddyPress settings */
-        'buddypress',
-
-        /* Your plugin's section id */
-        'bp_media_section'
-    );
-
-    /*
-       This is where you add your setting to BuddyPress ones
-       Here you are directly using intval as your validation function
-    */
-    register_setting(
-        /* BuddyPress settings */
-        'buddypress',
-
-        /* the option name you want to use for your plugin */
-        'bp-media-shared-gallery',
-
-        /* the validatation function you use before saving your option to the database */
-        'intval'
-    );
+	/*
+	   This is where you add your setting to BuddyPress ones
+	   Here you are directly using intval as your validation function
+	*/
+	register_setting(
+		/* BuddyPress settings */
+		'buddypress',
+		/* the option name you want to use for your plugin */
+		'bp-media-shared-gallery',
+		/* the validatation function you use before saving your option to the database */
+		'intval'
+	);
 }
 add_action( 'bp_register_admin_settings', 'bp_media_admin_settings', 999 );
 


### PR DESCRIPTION
Fixes #20 

While working with this and trying to hide tab, an issue was found with RTMedia activated so a separate issue #27 was created.

In this update, a multicheck option was created with user roles to restrict the Media tab to. If all are left unchecked then all roles will be allowed. This will be useful for integration with membership plugins that change user role based on subscription.